### PR TITLE
Fix search API call from POST to GET with query params

### DIFF
--- a/client/lib/search.ts
+++ b/client/lib/search.ts
@@ -45,18 +45,17 @@ export async function performSearch(
     throw new Error("Search query cannot be empty.");
   }
 
-  const response = await fetch("/api/search", {
-    method: "POST",
+  const params = new URLSearchParams({
+    q: trimmed,
+    limit: String(100),
+    lang: "en",
+  });
+
+  const response = await fetch(`/api/search?${params.toString()}`, {
+    method: "GET",
     headers: {
-      "Content-Type": "application/json",
       Accept: "application/json",
     },
-    body: JSON.stringify({
-      token: import.meta.env.LEAKOSINT_API_KEY,
-      request: trimmed,
-      limit: 100,
-      lang: "en",
-    }),
   });
 
   const body = await readResponseBody(response);


### PR DESCRIPTION
## Purpose
Fix search functionality that was failing with 400 errors and "invalid query" popup messages. The user reported that typing a search query and clicking the search button was not working properly, showing errors in the console and displaying error popups instead of performing the search.

## Code changes
- Changed search API call from POST to GET method
- Moved search parameters from request body to URL query parameters
- Removed `Content-Type: application/json` header (not needed for GET requests)
- Converted parameters to URLSearchParams format:
  - `q`: search query
  - `limit`: set to 100
  - `lang`: set to "en"
- Removed API token from client-side request body

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e852b7e016ad4fb1a5d244267996a8d9/zenith-zone)

👀 [Preview Link](https://e852b7e016ad4fb1a5d244267996a8d9-zenith-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e852b7e016ad4fb1a5d244267996a8d9</projectId>-->
<!--<branchName>zenith-zone</branchName>-->